### PR TITLE
[FIX] make sure nodes are disposed in more cases

### DIFF
--- a/src/owner.ts
+++ b/src/owner.ts
@@ -79,7 +79,6 @@ export class Owner {
   dispose(this: Owner, self = true): void {
     if (this._state === STATE_DISPOSED) return
 
-    const head = self ? this._prevSibling : this
     let current = this._nextSibling as Computation | null
 
     while (current && current._parent === this) {
@@ -88,13 +87,15 @@ export class Owner {
       current = current._nextSibling as Computation
     }
 
+    const head = self ? this._prevSibling : this
     if (self) this._disposeNode()
-    if (current) current._prevSibling = !self ? this : this._prevSibling
+    else if (current) current._prevSibling = this
     if (head) head._nextSibling = current
   }
 
   _disposeNode(): void {
-    if (this._prevSibling) this._prevSibling._nextSibling = null
+    if (this._nextSibling) this._nextSibling._prevSibling = this._prevSibling
+    // the other direction of links is handled by the dispose function
     this._parent = null
     this._prevSibling = null
     this._context = null

--- a/tests/onCleanup.test.ts
+++ b/tests/onCleanup.test.ts
@@ -81,3 +81,44 @@ it('should clean up in reverse order', () => {
   expect(disposeA).toHaveBeenCalledWith(2)
   expect(disposeParent).toHaveBeenCalledWith(3)
 })
+
+it('should dispose all roots', () => {
+  const disposals: string[] = []
+
+  const dispose = createRoot((dispose) => {
+    createRoot(() => {
+      onCleanup(() => disposals.push('SUBTREE 1'))
+      createEffect(() => onCleanup(() => disposals.push('+A1')))
+      createEffect(() => onCleanup(() => disposals.push('+B1')))
+      createEffect(() => onCleanup(() => disposals.push('+C1')))
+    })
+
+    createRoot(() => {
+      onCleanup(() => disposals.push('SUBTREE 2'))
+      createEffect(() => onCleanup(() => disposals.push('+A2')))
+      createEffect(() => onCleanup(() => disposals.push('+B2')))
+      createEffect(() => onCleanup(() => disposals.push('+C2')))
+    })
+
+    onCleanup(() => disposals.push('ROOT'))
+
+    return dispose
+  })
+
+  flushSync()
+  dispose()
+
+  expect(disposals).toMatchInlineSnapshot(`
+    [
+      "+C2",
+      "+B2",
+      "+A2",
+      "SUBTREE 2",
+      "+C1",
+      "+B1",
+      "+A1",
+      "SUBTREE 1",
+      "ROOT",
+    ]
+  `)
+})


### PR DESCRIPTION
The first item in every ownership scope would be dropped in some cases. This attempts to refactor the linked list mutations to fix that (and adds a test for a failing case)